### PR TITLE
feat: añadir validaciones para tipo_combustible en clase Vehiculo

### DIFF
--- a/code/Vehicle.py
+++ b/code/Vehicle.py
@@ -10,6 +10,9 @@ class Vehiculo:
         estadoActual (str): El estado actual del vehículo.
         tipoCombustible (str): El tipo de combustible que utiliza el vehículo.
     """
+
+    TIPOS_COMBUSTIBLE_VALIDOS = ["Gasolina", "Diesel", "Eléctrico"]
+
     def __init__(self, marca, modelo, año, kilometraje, estadoActual, 
     tipoCombustible):
         self.marca = marca
@@ -17,7 +20,7 @@ class Vehiculo:
         self.año = año
         self.kilometraje = kilometraje
         self.estadoActual = estadoActual
-        self.tipoCombustible = tipoCombustible
+        self.setTipoCombustible(tipoCombustible)
 
     # Getters
     def getMarca(self):
@@ -127,4 +130,6 @@ class Vehiculo:
         Args:
             tipoCombustible (str): El nuevo tipo de combustible.
         """
+        if tipoCombustible not in Vehiculo.TIPOS_COMBUSTIBLE_VALIDOS:
+            raise ValueError("Tipo de combustible inválido. Debe ser uno de: {Vehiculo.TIPOS_COMBUSTIBLE_VALIDOS}")
         self.tipoCombustible = tipoCombustible


### PR DESCRIPTION
Este pull request introduce una validación en la clase Vehiculo para garantizar que el atributo tipoCombustible solo acepte valores predefinidos. Los valores permitidos son: "Gasolina", "Diesel" y "Eléctrico". Si se intenta asignar un valor diferente, el sistema lanzará una excepción ValueError para asegurar la integridad de los datos.

Cambios realizados:
Se ha añadido una lista estática TIPOS_COMBUSTIBLE_VALIDOS que contiene los tipos de combustible permitidos.
El método setTipoCombustible ha sido modificado para realizar una validación sobre el tipo de combustible. Si el valor proporcionado no está en la lista de combustibles permitidos, se lanza un ValueError.
La validación también se ejecuta en el constructor de la clase Vehiculo, garantizando que solo se creen instancias válidas.

Proposito:
Este cambio mejora la validación de datos dentro del sistema, asegurando que los vehículos solo puedan tener un tipo de combustible válido. Esto ayuda a evitar errores y mantiene la consistencia en la base de datos.